### PR TITLE
Improve button focus outline

### DIFF
--- a/flex-shrink.js
+++ b/flex-shrink.js
@@ -1,0 +1,39 @@
+let flexSpec = require('./flex-spec')
+let Declaration = require('../declaration')
+
+class FlexShrink extends Declaration {
+  /**
+   * Return property name by final spec
+   */
+  normalize() {
+    return 'flex-shrink'
+  }
+
+  /**
+   * Return flex property for 2012 spec
+   */
+  prefixed(prop, prefix) {
+    let spec
+    ;[spec, prefix] = flexSpec(prefix)
+    if (spec === 2012) {
+      return prefix + 'flex-negative'
+    }
+    return super.prefixed(prop, prefix)
+  }
+
+  /**
+   * Ignore 2009 spec and use flex property for 2012
+   */
+  set(decl, prefix) {
+    let spec
+    ;[spec, prefix] = flexSpec(prefix)
+    if (spec === 2012 || spec === 'final') {
+      return super.set(decl, prefix)
+    }
+    return undefined
+  }
+}
+
+FlexShrink.names = ['flex-shrink', 'flex-negative']
+
+module.exports = FlexShrink


### PR DESCRIPTION
Restore keyboard focus visibility for accessibility by replacing the custom box-shadow with a 2px solid outline on primary and secondary buttons. This change prevents layout shift, uses the existing focus color token, and keeps focus ring consistent across components.