### PR TITLE
Debounce search input

### DIFF
--- a/refresh_expiration.lua
+++ b/refresh_expiration.lua
@@ -1,0 +1,11 @@
+local refresh_expiration = function (now, nextRequest, groupTimeout)
+
+  if groupTimeout ~= nil then
+    local ttl = (nextRequest + groupTimeout) - now
+
+    for i = 1, #KEYS do
+      redis.call('pexpire', KEYS[i], ttl)
+    end
+  end
+
+end


### PR DESCRIPTION
Add a 300ms debounce to the search input to reduce excessive API calls and prevent unnecessary re-renders while typing. Updates SearchBar component to use lodash.debounce and cleans up the effect on unmount.